### PR TITLE
Additional changes in July

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react-app-rewire-svgr": "^1.1.0",
     "react-app-rewired": "^1.5.2",
     "react-dom": "^16.2.0",
+    "react-number-format": "^3.4.3",
     "react-redux": "^5.0.6",
     "react-scripts": "1.0.17",
     "react-window-size": "^1.2.0",

--- a/public/test.html
+++ b/public/test.html
@@ -9,13 +9,14 @@
       body {
         margin: 0;
         background-color: #F7F8F8;
+        padding: 100px;
       }
     </style>
   </head>
   <body>
     Some content above
     <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.6.1/iframeResizer.min.js"></script>
-    <iframe id='insurance-model' src='https://insurance-model.netlify.com' frameborder='0' style="width: 100%; border: 0;"></iframe>
+    <iframe id='insurance-model' src='http://localhost:3000' frameborder='0' style="width: 100%; border: 0;"></iframe>
     <script>iFrameResize({}, '#insurance-model')</script>
     Some content below
   </body>

--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -20,6 +20,7 @@ import FinalChartLabel from './FinalChartLabel';
 import colors from '../theme/colors';
 import parseNumbersObject from '../helpers/parseNumbersObject';
 import Return from '../calculations/Return';
+import CustomTooltip from './CustomTooltip';
 
 const renderDot = (props) => {
   const {
@@ -64,7 +65,6 @@ class Chart extends Component {
         age,
         portfoliosReturn,
         mutualFundsReturn,
-        difference: portfoliosReturn - mutualFundsReturn,
       });
     });
   }
@@ -96,7 +96,7 @@ class Chart extends Component {
              <CartesianGrid stroke={colors.haze} vertical={false} />
              <Tooltip
                formatter={(val) => numeral(val).format('$0,0')}
-               wrapperStyle={styles.tooltip.container}
+               content={<CustomTooltip />}
              />
              <Legend
                margin={{ top: 20 }}
@@ -150,13 +150,6 @@ const styles = {
     },
     age: {
       fill: colors.evenDarkerGrey,
-    },
-  },
-  tooltip: {
-    container: {
-      border: 0,
-      boxShadow: `1px 1px 15px ${colors.shadowBlack}`,
-      borderRadius: '5px',
     },
   },
   legend: {

--- a/src/components/Checkboxes.js
+++ b/src/components/Checkboxes.js
@@ -10,6 +10,7 @@ const Checkboxes = (props) => (
       styles.container,
       props.medium && styles.medium.container,
       props.small && styles.small.container,
+      props.verySmall && styles.verySmall.container,
     ]}
   >
     <CheckboxField
@@ -59,6 +60,11 @@ const styles = {
     container: {
       height: '80px',
       backgroundColor: colors.haze,
+    },
+  },
+  verySmall: {
+    container: {
+      height: '120px',
     },
   },
 };

--- a/src/components/CustomTooltip.js
+++ b/src/components/CustomTooltip.js
@@ -1,0 +1,72 @@
+import React, { Component } from 'react';
+import Radium from 'radium';
+import _ from 'lodash';
+
+import colors from '../theme/colors';
+
+class Tooltip extends Component {
+  savings() {
+    return this.getData('portfoliosReturn').value -
+      this.getData('mutualFundsReturn').value;
+  }
+
+  getData(dataKey) {
+    const {
+      payload,
+    } = this.props;
+
+    return _.find(payload, { dataKey });
+  }
+
+  render() {
+    const {
+      active,
+      label,
+      payload,
+      formatter,
+    } = this.props;
+
+    if (!active) return null;
+
+    return (
+      <div style={styles.container}>
+        <div style={[styles.line, styles.age]}>
+          Age: {label}
+        </div>
+
+        {_.map(payload, ({ name, value, stroke }) => (
+          <div key={name} style={{ ...styles.line, ...{ color: stroke }}}>
+            {name}: {formatter(value)}
+          </div>
+        ))}
+
+        <div style={[styles.line, styles.savings]}>
+          Savings: {formatter(this.savings())}
+        </div>
+      </div>
+    );
+  }
+};
+
+export default Radium(Tooltip);
+
+const styles = {
+  container: {
+    border: 0,
+      boxShadow: `1px 1px 15px ${colors.shadowBlack}`,
+      borderRadius: '5px',
+      background: colors.white,
+      padding: '10px',
+  },
+  line: {
+    paddingBottom: '5px',
+  },
+  age: {
+    fontWeight: 600,
+    fontSize: '18px',
+    paddingBottom: '10px',
+  },
+  savings: {
+    fontWeight: 600,
+  },
+};

--- a/src/components/HelpIcon.js
+++ b/src/components/HelpIcon.js
@@ -8,8 +8,8 @@ import Icon from './Icon';
 const CONTENT = {
   initialInvestment: 'This is the amount you plan on investing initially.  If you currently have no savings, indicate $0.',
   pacMonth: 'This is the amount you intend to contribute each month.',
-  primaryCiAmount: 'Critical illness insurance coverage typically ranges between $20,000 to $150,000 based on a number of factors.  To find out the precise amount that you and your partner should be covered for, build a financial plan [link], it only takes 3 minutes.',
-  secondaryCiAmount: 'This refers to the critical illness coverage of your spouse.  Coverage typically ranges between $20,000 to $150,000 and is based on a number of factors.  To find out the precise amount that you and your partner should be covered for, build a financial plan [link], it only takes 3 minutes.',
+  primaryCiAmount: "Critical illness insurance coverage typically ranges between $20,000 to $150,000 based on a number of factors.  To find out the precise amount that you and your partner should be covered for, <a href='https://my.planswell.ca/discovery/ORG-InsCalc' target='_blank'>build a financial plan</a>, it only takes 3 minutes.",
+  secondaryCiAmount: "This refers to the critical illness coverage of your spouse.  Coverage typically ranges between $20,000 to $150,000 and is based on a number of factors.  To find out the precise amount that you and your partner should be covered for, <a href='https://my.planswell.ca/discovery/ORG-InsCalc' target='_blank'>build a financial plan</a>, it only takes 3 minutes.",
   primaryCiCost: 'This is the monthly cost of your critical illness insurance coverage, usually ranging from $15-$70 per month',
   secondaryCiCost: 'This is the monthly cost of your spouses critical illness insurance coverage, usually ranging from $15-$70 per month',
   currentAge: 'Enter your current age here.',
@@ -38,9 +38,10 @@ const HelpIcon = ({ name, label, small, tooltipUp }) => (
         {small && <div style={styles.modal.headline}>
           {label}
         </div>}
-        <div style={[styles.modal.description, small && styles.small.modal.description]}>
-          {CONTENT[name]}
-        </div>
+        <div
+          style={[styles.modal.description, small && styles.small.modal.description]}
+          dangerouslySetInnerHTML={{ __html: CONTENT[name] }}
+        />
       </div>
     )}
   </Popup>

--- a/src/components/MainForm.js
+++ b/src/components/MainForm.js
@@ -112,14 +112,14 @@ class MainForm extends Component {
         <TextField
           name='portfoliosFeesPercentage'
           label='Portfolios Fees'
-          suffix='%'
+          suffix='％'
           {...this.props}
         />
 
         <TextField
           name='mutualFundsFeesPercentage'
           label='Mutual Fund Fees'
-          suffix='%'
+          suffix='％'
           tooltipUp
           {...this.props}
         />
@@ -127,7 +127,7 @@ class MainForm extends Component {
         <TextField
           name='rateOfReturnPercentage'
           label='Avg Rate of Return'
-          suffix='%'
+          suffix='％'
           tooltipUp
           {...this.props}
         />

--- a/src/components/MainForm.js
+++ b/src/components/MainForm.js
@@ -47,42 +47,48 @@ class MainForm extends Component {
         <TextField
           name='initialInvestment'
           label='Initial Investment'
-          suffix='$'
+          prefix='$'
+          thousandSeparator
           {...this.props}
         />
 
         <TextField
           name='pacMonth'
           label='PAC / Month'
-          suffix='$'
+          prefix='$'
+          thousandSeparator
           {...this.props}
         />
 
         <TextField
           name='primaryCiAmount'
           label='Primary CI Amount'
-          suffix='$'
+          prefix='$'
+          thousandSeparator
           {...this.props}
         />
 
         <TextField
           name='secondaryCiAmount'
           label='Secondary CI Amount'
-          suffix='$'
+          prefix='$'
+          thousandSeparator
           {...this.props}
         />
 
         <TextField
           name='primaryCiCost'
           label='Primary CI Cost'
-          suffix='$'
+          prefix='$'
+          thousandSeparator
           {...this.props}
         />
 
         <TextField
           name='secondaryCiCost'
           label='Secondary CI Cost'
-          suffix='$'
+          prefix='$'
+          thousandSeparator
           {...this.props}
         />
         <TextField

--- a/src/components/TextField.js
+++ b/src/components/TextField.js
@@ -96,6 +96,7 @@ const styles = {
   verySmall: {
     container: {
       width: 'calc(50% - 2px)',
+      minWidth: '80px',
     },
   },
 };

--- a/src/components/TextField.js
+++ b/src/components/TextField.js
@@ -93,7 +93,7 @@ const styles = {
   verySmall: {
     container: {
       width: 'calc(50% - 2px)',
-      minWidth: '80px',
+      minWidth: 'initial',
     },
   },
 };

--- a/src/components/TextField.js
+++ b/src/components/TextField.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Field } from 'redux-form';
 import Radium from 'radium';
+import NumberFormat from 'react-number-format';
 
 import colors from '../theme/colors';
 import HelpIcon from './HelpIcon';
@@ -10,6 +11,8 @@ export default (props) => {
     name,
     label,
     suffix,
+    prefix,
+    thousandSeparator,
     verySmall,
     small,
   } = props;
@@ -25,15 +28,15 @@ export default (props) => {
           {label} <HelpIcon {...props} />
         </label>
         <div style={[styles.field.container, active && styles.field.active]}>
-          <input
+          <NumberFormat
             {...input}
             placeholder=''
             type='text'
+            thousandSeparator={thousandSeparator}
             style={styles.field.input}
+            prefix={prefix && prefix + ' '}
+            suffix={suffix && ' ' + suffix}
           />
-          {suffix && <span style={styles.field.suffix}>
-            {suffix}
-          </span>}
         </div>
       </div>
     ))}
@@ -71,17 +74,11 @@ const styles = {
     },
     input: {
       textAlign: 'right',
-      width: '80px',
+      width: '100%',
       fontSize: '21px',
       fontWeight: 600,
       border: 0,
       outline: 0,
-    },
-    suffix: {
-      display: 'inline-block',
-      paddingLeft: '5px',
-      fontSize: '21px',
-      fontFamily: 'Lato Medium',
     },
     active: {
       borderBottom: `1px solid ${colors.blue}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6076,6 +6076,13 @@ react-error-overlay@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-3.0.0.tgz#c2bc8f4d91f1375b3dad6d75265d51cd5eeaf655"
 
+react-number-format@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-3.4.3.tgz#8bccc08e4ecfb9553548574589af457541a706fd"
+  dependencies:
+    babel-runtime "^6.26.0"
+    prop-types "^15.6.0"
+
 react-redux@^5.0.6:
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.6.tgz#23ed3a4f986359d68b5212eaaa681e60d6574946"


### PR DESCRIPTION
Introduces these changes:
1. On the tool tips, there is a [LINK] section that we would like to update to the following link: https://my.planswell.ca/discovery/ORG-InsCalc
2. The webpage embed is not stacking well due to the width of the input fields, can we adjust slightly?
3. Can we put the $ signs on the left hand side of the fields.
4. can there be commas separating $1,000 in the amount fields that are $ amounts?

Demo:
https://insurance-model.netlify.com

<img width="1280" alt="screen shot 2018-07-16 at 22 14 59" src="https://user-images.githubusercontent.com/1877286/42778508-f5a48f18-8945-11e8-962c-385f72aaaf1c.png">
<img width="448" alt="screen shot 2018-07-16 at 22 16 19" src="https://user-images.githubusercontent.com/1877286/42778509-f730da6c-8945-11e8-87f0-319011558e94.png">
<img width="245" alt="screen shot 2018-07-16 at 22 16 25" src="https://user-images.githubusercontent.com/1877286/42778512-f9322c26-8945-11e8-949f-3f124915374f.png">
